### PR TITLE
Fix CI by updating to latest Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
CI [failed](https://github.com/rust-diplomat/book/actions/runs/13102220791/job/36563689567) for [my latest PR](https://github.com/rust-diplomat/book/pull/11) due to mdBook requiring at least GLIBC_2.32. The current CI image is Ubuntu 20.04 which has an older version than that.